### PR TITLE
Add Section Header to alu.properties

### DIFF
--- a/biomaj_data/db_properties/alu.properties
+++ b/biomaj_data/db_properties/alu.properties
@@ -1,4 +1,4 @@
-
+[GENERAL]
 ######################
 ### Initialization ###
 


### PR DESCRIPTION
to fix:

```
Configuration file error File contains no section headers.
file: '/var/lib/biomaj/data/conf/alu.properties', line: 5
'db.fullname="alu.n : alu repeat element. alu.a : translation of alu.n repeats"\n'
```