### PR TITLE
replace more by cat

### DIFF
--- a/process/makeblastdb.sh
+++ b/process/makeblastdb.sh
@@ -178,7 +178,7 @@ fi
 for fileIndexVirtuel in $lsAl 
 do
   echo "Found alias file: [$fileIndexVirtuel]";
-  listIndex=`more $fileIndexVirtuel | grep DBLIST`;
+  listIndex=`cat $fileIndexVirtuel | grep DBLIST`;
   listFile2="";
   for f in $listIndex
   do


### PR DESCRIPTION
Hi,

I noticed that working with big genome size file like wheat, `more | grep` is not working.
I would recommend using `cat` instead.

Cheers,